### PR TITLE
single organism parameter not seen bugfix issue #1

### DIFF
--- a/theme/cottongen/mainlab_organism_base.tpl.php
+++ b/theme/cottongen/mainlab_organism_base.tpl.php
@@ -11,7 +11,7 @@ $properties = $node->organism->organismprop;
 $prop = array();
 $count_cname = 0;
 if ($properties) {
-  foreach ($properties AS $p) {
+  foreach (is_array($properties)?$properties:array($properties) AS $p) {
     $prop[$p->type_id->name] = $p->value;
     if ($p->type_id->name == 'alias_common') {
       $count_cname ++;


### PR DESCRIPTION
Bugfix for issue #1, where if there is only one entry in the chado.organismprop table for an organism, then this property does not appear in the organism summary page generated by theme/cottongen/mainlab_organism_base.tpl.php